### PR TITLE
turn off slack notification while gh action is failing

### DIFF
--- a/.github/workflows/update-deepgram-sdk.yaml
+++ b/.github/workflows/update-deepgram-sdk.yaml
@@ -2,7 +2,7 @@ name: Update Deepgram SDK
 
 on:
   schedule:
-    - cron: '0 0 * * 1'  # Runs every Monday at midnight
+    - cron: "0 0 * * 1" # Runs every Monday at midnight
   workflow_dispatch:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install required tools
         run: sudo apt-get install -y jq curl
@@ -37,7 +37,7 @@ jobs:
         run: |
           LATEST_VERSION=${{ env.version }}
           INSTALLED_VERSION=${{ env.installed_version }}
-          
+
           if [ "$LATEST_VERSION" != "$INSTALLED_VERSION" ]; then
             echo "Updating Deepgram SDK from $INSTALLED_VERSION to $LATEST_VERSION"
             pip install deepgram-sdk==$LATEST_VERSION
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r requirements.txt
-      
+
       - name: Install dev dependencies
         run: pip install -r requirements-dev.txt
 
@@ -71,24 +71,24 @@ jobs:
           DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
         run: pytest tests/
 
-      - name: Notify on failure
-        if: failure()
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "text": "The tests have FAILED for ${{ github.repository }}."
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          
-      - name: Notify on success
-        if: success()
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "text": "The tests have passed for ${{ github.repository }}."
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # - name: Notify on failure
+      #   if: failure()
+      #   uses: slackapi/slack-github-action@v1.23.0
+      #   with:
+      #     payload: |
+      #       {
+      #         "text": "The tests have FAILED for ${{ github.repository }}."
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      # - name: Notify on success
+      #   if: success()
+      #   uses: slackapi/slack-github-action@v1.23.0
+      #   with:
+      #     payload: |
+      #       {
+      #         "text": "The tests have passed for ${{ github.repository }}."
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The Github action `update-deepgram-sdk` if currently failing when run. This is because I added branch protection to the project, so the action needs to be updated to push to a different branch and then merge to main. 

I'm turning off the slack notifications that get sent out when the action fails/passes. Will turn back on after the GH action is fixed.