### PR TITLE
Add a README section about SSL validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ python app.py
 python app_socketio.py
 ```
 
+#### SSL Error
+
+If the SocketIO app raises an `WebSocketException` with CERTIFICATE_VERIFY_FAILED, you can add these lines in order to use the `certifi` trust files.
+```python
+# file:app_socketio.py
+import os
+# Add this import
+import certifi
+
+# Add this line anywhere before `dg_connection.start`
+os.environ["SSL_CERT_FILE"] = certifi.where()
+```
+
 ## Testing
 
 To contribute or modify pytest code, install the following dependencies:


### PR DESCRIPTION
As per https://github.com/deepgram-starters/live-flask-starter/issues/12, I encountered an issue with SSL cert validation and I thought it could be useful to add a note in the README. I don't know if it's just me or it could help others (or worse, misdirect).
Thank you!