### PR TITLE
chore: update Deepgram SDK to v4.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepgram-sdk==v3.10.1
+deepgram-sdk==v4.6.0
 Flask==3.0.0
 Flask-SocketIO==5.3.6
 python-dotenv==1.0.0


### PR DESCRIPTION
This PR updates the Deepgram SDK to version v4.6.0.